### PR TITLE
Do not use the message factory in the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Message factory is not invoked in the client constructor
+
 
 ## [0.2.1] - 2018-04-26
 

--- a/protoc-gen-twirp_php/templates/global/TwirpClient.php
+++ b/protoc-gen-twirp_php/templates/global/TwirpClient.php
@@ -267,12 +267,18 @@ abstract class TwirpClient
      */
     final protected function urlBase($addr)
     {
-        $url = $this->messageFactory->createRequest('POST', $addr)->getUri();
+        $scheme = parse_url($addr, PHP_URL_SCHEME);
 
-        if ($url->getScheme() == '') {
-            $url = $url->withScheme('http');
+        // If parse_url fails, return the addr unchanged.
+        if ($scheme === false) {
+            return $addr;
         }
 
-        return $url;
+        // If the addr does not specify a scheme, default to http.
+        if (empty($scheme)) {
+            $addr = 'http://'.ltrim($addr, ':/');
+        }
+
+        return $addr;
     }
 }

--- a/protoc-gen-twirp_php/templates/service/Client.php
+++ b/protoc-gen-twirp_php/templates/service/Client.php
@@ -52,7 +52,7 @@ final class {{ .Service | phpServiceName .File }}Client extends TwirpClient impl
 
         $out = new {{ $method.OutputType | phpMessageName }}();
 
-        $url = (string)$this->addr->withPath('/twirp/{{ $method | protoFullName $.File $.Service }}');
+        $url = $this->addr.'/twirp/{{ $method | protoFullName $.File $.Service }}';
 
         $this->doProtobufRequest($ctx, $url, $in, $out);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9
| License         | MIT


#### What's in this PR?

The client does not invoke the message factory in the constructor anymore to create the base URL.


#### Why?

It was not really nice to invoke any code in the constructor. It also made using mocks harder.

