### PR TITLE
Add version conflict to composer for protobuf package lower than 3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
         "google/protobuf": "^3.5",
         "php-http/guzzle6-adapter": "^1.0"
     },
+    "conflict": {
+        "google/protobuf": "<3.5"
+    },
     "autoload": {
         "psr-4": {
             "Twirp\\": "php/src/"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #17
| License         | MIT


