### PR TITLE
Fix panic when no proto options are defined

### DIFF
--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -62,11 +62,11 @@ func ClassNamePrefix(className string, file *descriptor.FileDescriptorProto) str
 // 1. Explicitly set namespace using the "php_namespace" option
 // 2. Package name with dots replaced with backslashes and segments converted to title
 func Namespace(file *descriptor.FileDescriptorProto) string {
-	options := file.GetOptions()
-
-	// When there is a namespace option defined we use it
-	if options.PhpNamespace != nil {
-		return options.GetPhpNamespace()
+	if options := file.GetOptions(); options != nil {
+		// When there is a namespace option defined we use it
+		if options.PhpNamespace != nil {
+			return options.GetPhpNamespace()
+		}
 	}
 
 	return Name(file.GetPackage())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #35
| License         | MIT


When there are no options defined in a proto file, the options descriptor struct will be nil.
The namespace generator function used this struct regardless of that fact which caused a panic.