### PR TITLE
Add ability to change prefix to client for v7 compatibility

### DIFF
--- a/protoc-gen-twirp_php/templates/service/AbstractClient.php
+++ b/protoc-gen-twirp_php/templates/service/AbstractClient.php
@@ -73,7 +73,7 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
-        $this->prefix = '/twirp';
+        $this->prefix = 'twirp';
     }
 {{ range $method := .Service.Method }}
 {{- $inputType := $method.InputType | phpMessageName }}

--- a/protoc-gen-twirp_php/templates/service/AbstractClient.php
+++ b/protoc-gen-twirp_php/templates/service/AbstractClient.php
@@ -55,7 +55,8 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
         $addr,
         ClientInterface $httpClient = null,
         RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null
+        StreamFactoryInterface $streamFactory = null,
+        string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {
             $httpClient = Psr18ClientDiscovery::find();
@@ -73,7 +74,7 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
-        $this->prefix = 'twirp';
+        $this->prefix = ltrim(rtrim($prefix, '/'), '/');
     }
 {{ range $method := .Service.Method }}
 {{- $inputType := $method.InputType | phpMessageName }}
@@ -255,14 +256,5 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
         }
 
         return $addr;
-    }
-
-    /**
-     * Set url path prefix. Default is twirp.
-     * @param string $prefix 
-     */
-    public function setPrefix(string $prefix)
-    {
-        $this->prefix = ltrim(rtrim($prefix, '/'), '/');
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #40 
| License         | MIT


**What's in this PR?**

Add setPrefix to clients to allow setting url path prefix for v7 compatibility.

**Example Usage**
```php
<?php

$client = new HaberdasherClient('http://127.0.0.1:8080');
$client->setPrefix('/my/special/prefix');

// or to have no prefix
$client->setPrefix('');

// use client like normal
```

**To Do**
- [ ] generate examples once we agree on approach.
