### PR TITLE
Exclude protoc-gen-twirp_php from composer archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,5 +53,12 @@
         }
     },
     "prefer-stable": true,
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "archive": {
+        "exclude": [
+            "/vendor/*",
+            "/.idea/*",
+            "/protoc-gen-twirp_php/*"
+        ]
+    }
 }


### PR DESCRIPTION
**What's in this PR?**

Exclude protoc-gen-twirp_php and other unneeded files from the composer archive. They are not needed by users.

**Why?**

We do not need to include the generator code - php templates and go - in the composer archive.  This can be confusing and/or pollute users projects.


