### PR TITLE
Ignore unkown fields

### DIFF
--- a/protoc-gen-twirp_php/templates/service/Server.php
+++ b/protoc-gen-twirp_php/templates/service/Server.php
@@ -146,7 +146,7 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
             $ctx = $this->hook->requestRouted($ctx);
 
             $in = new {{ $inputType }}();
-            $in->mergeFromJsonString((string)$req->getBody());
+            $in->mergeFromJsonString((string)$req->getBody(), true);
 
             $out = $this->svc->{{ $method.Desc.Name }}($ctx, $in);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #46
| License         | MIT


**What's in this PR?**
When decoding JSON, Twirp (Go) allows unknown fields. See example.

In Protobuf 3.12, an option was added to ignore unknown fields for PHP. The runtime behavior varies depending on whether or not you have the Protobuf extension installed. See protocolbuffers/protobuf#8514.

**Why?**
To mirror twitchtv/twirp, twirphp should allow unknown fields when unmarshalling JSON.

**Example Usage**
See https://github.com/mterwill/proto-unknown-fields

**Attribution**
Originally submitted by @mterwill in #46, resubmitted to resolve conflicts