### PR TITLE
fix: segfault when input proto file does not specify options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix segfault when input proto file does not specify options
+
 
 ## [0.7.1] - 2021-04-21
 

--- a/protoc-gen-twirp_php/main.go
+++ b/protoc-gen-twirp_php/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/twirphp/twirp/protoc-gen-twirp_php/internal/gen"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
@@ -46,7 +47,10 @@ func Main(in io.Reader, out io.Writer) error {
 	// This is an ugly hack to make sure we bypass Go requirements
 	for _, fd := range req.GetProtoFile() {
 		pkg := "dummy/path"
-		fd.GetOptions().GoPackage = &pkg
+		if fd.Options == nil {
+			fd.Options = &descriptorpb.FileOptions{}
+		}
+		fd.Options.GoPackage = &pkg
 	}
 
 	options := protogen.Options{}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no|
| BC breaks?      | no|yes
| Deprecations?   | no|
| Related tickets | -
| License         | MIT


**What's in this PR?**
This fixes a bug in protoc-gen-twirp_php that occurs when compiling an input file that does not specify any options.

**Why?**
The following is a valid protobuf file:

```proto
syntax = "proto3";

package foo;

service Foo {
}
```

Currently when you run protoc-gen-twirp_php against this file, it segfaults:

```
$ protoc --twirp_php_out=gen/ foo.proto
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13b867b]

goroutine 1 [running]:
main.Main(0x14f4220, 0xc000010010, 0x14f4240, 0xc000010018, 0x0, 0x0)
        /Volumes/cAseSensitive/twirphp/protoc-gen-twirp_php/main.go:49 +0xdb
main.main()
        /Volumes/cAseSensitive/twirphp/protoc-gen-twirp_php/main.go:33 +0x109
--twirp_php_out: protoc-gen-twirp_php: Plugin failed with status code 2.
```

**Checklist**
- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
