### PR TITLE
fix: namespacing bug when importing other proto files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixes
 
 - Fix segfault when input proto file does not specify options
+- Fix namespacing bug when importing other proto files
 
 
 ## [0.7.1] - 2021-04-21


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no|
| BC breaks?      | no|
| Deprecations?   | no|
| Related tickets | -
| License         | MIT


**What's in this PR? Why?**
protoc-gen-twirp_php currently incorrectly namespaces messages when importing other files with different namespaces. Instead of passing around the file we're generating to determine a message name, we should use the message's parent file. There's some proto type juggling involved here; I did the best I could to not make the change too intrusive.

On main right now:

```
$ ./test.sh
23c23
<     public function Foo(array $ctx, \Bar\Bar $req): \Google\Protobuf\GPBEmpty;
---
>     public function Foo(array $ctx, \Foo\Bar $req): \Foo\PBEmpty;
```

**Checklist**
- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

**To Do**
- [x] How do you want to test this? I committed some stuff just to show the before and after but wasn't planning to merge that as-is.