### PR TITLE
Add previous exception to the Twirp error for client errors

### DIFF
--- a/protoc-gen-twirp_php/templates/global/TwirpError.php.tmpl
+++ b/protoc-gen-twirp_php/templates/global/TwirpError.php.tmpl
@@ -72,13 +72,13 @@ final class TwirpError extends \Exception implements Error
      * error {type: Internal, msg: "invalid error type {code}"}. If you need to
      * add metadata, use setMeta(key, value) method after building the error.
      */
-    public static function newError(string $code, string $msg): self
+    public static function newError(string $code, string $msg, \Throwable $previous = null): self
     {
         if (ErrorCode::isValid($code)) {
-            return new self($code, $msg);
+            return new self($code, $msg, 0, $previous);
         }
 
-        return new self(ErrorCode::Internal, 'invalid error type '.$code);
+        return new self(ErrorCode::Internal, 'invalid error type '.$code, 0, $previous);
     }
 
     /**

--- a/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
@@ -133,7 +133,7 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
      */
     protected function clientError(string $desc, \Throwable $e): TwirpError
     {
-        return TwirpError::newError(ErrorCode::Internal, sprintf('%s: %s', $desc, $e->getMessage()));
+        return TwirpError::newError(ErrorCode::Internal, sprintf('%s: %s', $desc, $e->getMessage()), $e);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | yes
| License         | MIT


**What's in this PR?**

Add previous exception to client errors so that `getPrevious` on the TwirpError returns it.

**Why?**

Currently, the guzzle exception is not accessible from the client Twirp Error, this PR will allow it to be accessed for logging, metrics, some other handling.

**Example Usage**
```php
<?php

$foo = new Foo();

try {
  $foo->SayHello([]);
} catch (Exception $e) {
   $prev = $e->getPrevious();
// do something with $prev if it is not null
}
```


**To Do**
- [ ] regenerate examples
