### PR TITLE
bugfix: Ensure error code is an int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Fix TypeError when exceptions with string error codes are thrown
 
 ## [0.7.3] - 2021-06-29
 

--- a/example/generated/Twitch/Twirp/Example/TwirpError.php
+++ b/example/generated/Twitch/Twirp/Example/TwirpError.php
@@ -91,8 +91,9 @@ final class TwirpError extends \Exception implements Error
     public static function errorFrom(\Throwable $e, string $msg = ''): self
     {
         $msg = empty($msg) ? $e->getMessage() : $msg;
+        $code = is_int($e->getCode()) ? $e->getCode() : 0;
 
-        $err = new self(ErrorCode::Internal, $msg, $e->getCode(), $e);
+        $err = new self(ErrorCode::Internal, $msg, $code, $e);
         $err->setMeta('cause', $e->getMessage());
 
         return $err;

--- a/example/tests/TwirpErrorTest.php
+++ b/example/tests/TwirpErrorTest.php
@@ -102,4 +102,30 @@ final class TwirpErrorTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('custom msg', $error->getMessage());
         $this->assertEquals('msg', $error->getMeta('cause'));
     }
+
+    /**
+     * Exception->getCode is not guaranteed to return an int, even though the method has a type hint.
+     * See: https://www.php.net/manual/en/exception.getcode.php
+     * > Returns the exception code as int in Exception but possibly as other
+     * > type in Exception descendants (for example as string in PDOException).
+     *
+     * @test
+     */
+    public function it_works_with_string_codes(): void
+    {
+        $exception = new class('msg', 'code') extends \PDOException
+        {
+            public function __construct(string $msg, string $code)
+            {
+                parent::__construct($msg);
+                $this->code = $code;
+            }
+        };
+        $error = TwirpError::errorFrom($exception);
+
+        $this->assertEquals(ErrorCode::Internal, $error->getErrorCode());
+        $this->assertEquals('msg', $error->getMessage());
+        $this->assertEquals('msg', $error->getMeta('cause'));
+        $this->assertEquals(0, $error->getCode());
+    }
 }

--- a/protoc-gen-twirp_php/templates/global/TwirpError.php.tmpl
+++ b/protoc-gen-twirp_php/templates/global/TwirpError.php.tmpl
@@ -91,8 +91,10 @@ final class TwirpError extends \Exception implements Error
     public static function errorFrom(\Throwable $e, string $msg = ''): self
     {
         $msg = empty($msg) ? $e->getMessage() : $msg;
+        // Exception->getCode is not guaranteed to return an int, see https://www.php.net/manual/en/exception.getcode.php
+        $code = is_int($e->getCode()) ? $e->getCode() : 0;
 
-        $err = new self(ErrorCode::Internal, $msg, $e->getCode(), $e);
+        $err = new self(ErrorCode::Internal, $msg, $code, $e);
         $err->setMeta('cause', $e->getMessage());
 
         return $err;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| BC breaks?      | no|
| Deprecations?   | no|
| License         | MIT


**What's in this PR?**
While `Exception->getCode` is typed to return an int, it's still not guaranteed to. See: https://www.php.net/manual/en/exception.getcode.php

> Returns the exception code as int in Exception but possibly as other type in Exception descendants (for example as string in PDOException).

Ensure the code is an int before passing it into the constructor. String codes will still be accessible via the previous exception.

**Why?**
So that we do not inadvertently throw a `TypeError`.

**Checklist**
- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
