### PR TITLE
Server path prefix

### DIFF
--- a/example/server.php
+++ b/example/server.php
@@ -6,7 +6,7 @@ $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
 
 $server = new \Twirp\Server();
 $handler = new \Twitch\Twirp\Example\HaberdasherServer(new \Twirphp\Example\Haberdasher());
-$server->registerServer(\Twitch\Twirp\Example\HaberdasherServer::PATH_PREFIX, $handler);
+$server->registerServer($handler->getPathPrefix(), $handler);
 
 $response = $server->handle($request);
 

--- a/example/tests/HaberdasherFunctionalTest.php
+++ b/example/tests/HaberdasherFunctionalTest.php
@@ -51,4 +51,40 @@ final class HaberdasherFunctionalTest extends \PHPUnit\Framework\TestCase
 
         $hat = $haberdasherClient->MakeHat([], (new Size)->setInches(123));
     }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_response_with_empty_prefix(): void
+    {
+        $haberdasherServer = new HaberdasherServer(new Haberdasher(), null, null, null, '');
+
+        $httpClient = new Psr15HttpClient($haberdasherServer, new HttpFactory());
+
+        $haberdasherClient = new HaberdasherClient('www.example.com', $httpClient, null, null, '');
+
+        $hat = $haberdasherClient->MakeHat([], (new Size)->setInches(123));
+
+        $this->assertSame(123, $hat->getSize());
+        $this->assertSame('golden', $hat->getColor());
+        $this->assertSame('crown', $hat->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_response_with_custom_prefix(): void
+    {
+        $haberdasherServer = new HaberdasherServer(new Haberdasher(), null, null, null, '/custom/prefix');
+
+        $httpClient = new Psr15HttpClient($haberdasherServer, new HttpFactory());
+
+        $haberdasherClient = new HaberdasherClient('www.example.com', $httpClient, null, null, '/custom/prefix');
+
+        $hat = $haberdasherClient->MakeHat([], (new Size)->setInches(123));
+
+        $this->assertSame(123, $hat->getSize());
+        $this->assertSame('golden', $hat->getColor());
+        $this->assertSame('crown', $hat->getName());
+    }
 }

--- a/protoc-gen-twirp_php/templates/service/Server.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/Server.php.tmpl
@@ -25,7 +25,15 @@ use Twirp\ServerHooks;
  */
 final class {{ .Service | phpServiceName .File }}Server implements RequestHandlerInterface
 {
-    const PATH_PREFIX = '/twirp/{{ .Service.Desc.FullName }}/';
+    /**
+     * A convenience constant that may identify URL paths.
+     *
+     * Should be used with caution, it only matches routes with the default "/twirp" prefix
+     * and default CamelCase service and method names.
+     *
+     * Use {{ .Service | phpServiceName .File }}Server::getPathPrefix instead.
+     */
+    public const PATH_PREFIX = '/twirp/{{ .Service.Desc.FullName }}/';
 
     /**
      * @var ResponseFactoryInterface
@@ -47,11 +55,17 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
      */
     private $hook;
 
+    /**
+     * @var string
+     */
+    private $prefix;
+
     public function __construct(
         {{ .Service | phpServiceName .File }} $svc,
         ServerHooks $hook = null,
         ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null
+        StreamFactoryInterface $streamFactory = null,
+        string $prefix = '/twirp'
     ) {
         if ($hook === null) {
             $hook = new BaseServerHooks();
@@ -69,6 +83,17 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
         $this->hook = $hook;
         $this->responseFactory = $responseFactory;
         $this->streamFactory = $streamFactory;
+        $this->prefix = rtrim($prefix, '/');
+    }
+
+    /**
+     * Returns the base service path, in the form: "/<prefix>/<package>.<Service>/"
+     * that is everything in a Twirp route except for the <Method>. This can be used for routing,
+     * for example to identify the requests that are targeted to this service in a mux.
+     */
+    public function getPathPrefix(): string
+    {
+        return $this->prefix.'/{{ .Service.Desc.FullName }}/';
     }
 
     /**
@@ -94,7 +119,7 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
 
         switch ($req->getUri()->getPath()) {
             {{- range $method := .Service.Methods }}
-            case '/twirp/{{ $method | protoMethodFullName }}':
+            case $this->prefix.'/{{ $method | protoMethodFullName }}':
                 return $this->handle{{ $method.Desc.Name }}($ctx, $req);
             {{- end }}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**

Add support for server path prefix.

**What this PR does / why we need it**

As of the v7 spec, Twirp allows changing the URL prefix applied to each service.

The client already supported changing the prefix. This PR adds support for changing the prefix on the server side.

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- Consumers should now use `getPathPrefix()` instead of `PATH_PREFIX` constants
```
