### PR TITLE
Add Router instead of server

### DIFF
--- a/example/server.php
+++ b/example/server.php
@@ -1,23 +1,21 @@
 <?php
 
-require __DIR__.'/../lib/vendor/autoload.php';
+require __DIR__ . '/../lib/vendor/autoload.php';
 
 $request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
 
-$server = new \Twirp\Server();
 $handler = new \Twitch\Twirp\Example\HaberdasherServer(new \Twirphp\Example\Haberdasher());
-$server->registerServer($handler->getPathPrefix(), $handler);
 
-$response = $server->handle($request);
+$response = $handler->handle($request);
 
 if (!headers_sent()) {
-	// status
-	header(sprintf('HTTP/%s %s %s', $response->getProtocolVersion(), $response->getStatusCode(), $response->getReasonPhrase()), true, $response->getStatusCode());
-	// headers
-	foreach ($response->getHeaders() as $header => $values) {
-		foreach ($values as $value) {
-			header($header.': '.$value, false, $response->getStatusCode());
-		}
-	}
+    // status
+    header(sprintf('HTTP/%s %s %s', $response->getProtocolVersion(), $response->getStatusCode(), $response->getReasonPhrase()), true, $response->getStatusCode());
+    // headers
+    foreach ($response->getHeaders() as $header => $values) {
+        foreach ($values as $value) {
+            header($header . ': ' . $value, false, $response->getStatusCode());
+        }
+    }
 }
 echo $response->getBody();

--- a/lib/src/Router.php
+++ b/lib/src/Router.php
@@ -12,11 +12,9 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * Collects server implementations and routes requests based on their prefix.
- *
- * @deprecated since 0.9.0, will be removed before 1.0.0. Use Router instead.
+ * A Twirp-compatible multiplexer for serving multiple Twirp services at the same time.
  */
-final class Server implements RequestHandlerInterface
+final class Router implements RequestHandlerInterface
 {
     /**
      * @var ResponseFactoryInterface
@@ -49,9 +47,9 @@ final class Server implements RequestHandlerInterface
         $this->streamFactory = $streamFactory;
     }
 
-    public function registerServer(string $prefix, RequestHandlerInterface $server): void
+    public function registerHandler(string $path, RequestHandlerInterface $handler): void
     {
-        $this->handlers[$prefix] = $server;
+        $this->handlers[$path] = $handler;
     }
 
     /**
@@ -59,8 +57,8 @@ final class Server implements RequestHandlerInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        foreach ($this->handlers as $prefix => $handler) {
-            if (strpos($request->getUri()->getPath(), $prefix) === 0) {
+        foreach ($this->handlers as $path => $handler) {
+            if (strpos($request->getUri()->getPath(), $path) === 0) {
                 return $handler->handle($request);
             }
         }

--- a/lib/tests/RouterTest.php
+++ b/lib/tests/RouterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Twirp;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Uri;
+use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Twirp\ErrorCode;
+use Twirp\Router;
+
+final class RouterTest extends \PHPUnit\Framework\TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_handles_a_request(): void
+    {
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+
+        $server = new Router();
+
+        $server->registerHandler('/twirp/prefix', $handler->reveal());
+
+        $response = new Response();
+
+        $handler->handle(Argument::type(ServerRequestInterface::class))->willReturn($response);
+
+        $request = (ServerRequest::fromGlobals())->withUri(new Uri('http://localhost/twirp/prefix'));
+
+        $actualResponse = $server->handle($request);
+
+        self::assertSame($response, $actualResponse);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_no_route_error_when_a_request_cannot_be_routed_to_a_service(): void
+    {
+        $server = new Router();
+
+        $request = ServerRequest::fromGlobals();
+
+        $response = $server->handle($request);
+
+        $body = (string) $response->getBody();
+        $body = json_decode($body, true);
+
+        self::assertEquals(404, $response->getStatusCode());
+        self::assertEquals(ErrorCode::BadRoute, $body['code']);
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5,3 +5,7 @@ parameters:
 			count: 1
 			path: lib/src/Server.php
 
+		-
+			message: "#^Parameter \\#1 \\$content of method Psr\\\\Http\\\\Message\\\\StreamFactoryInterface\\:\\:createStream\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: lib/src/Router.php


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**

Add a new Router that replaces Server.

**What this PR does / why we need it**

We will likely want to use the name Server for something else.
Also, Router uses more generic terms as path (instead of prefix) and handler (instead of server).

Related #88
Related #89

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Deprecated `Server`. Use `Router` instead.
```
