### PR TITLE
Return error on prefix mismatch

### DIFF
--- a/example/tests/HaberdasherFunctionalTest.php
+++ b/example/tests/HaberdasherFunctionalTest.php
@@ -75,4 +75,19 @@ final class HaberdasherFunctionalTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('golden', $hat->getColor());
         $this->assertSame('crown', $hat->getName());
     }
+
+    public function testItReturnsABadPathErrorWhenThePrefixDoesNotMatch(): void
+    {
+        $haberdasherServer = new HaberdasherServer(new Haberdasher());
+
+        $httpClient = new Psr15HttpClient($haberdasherServer, new HttpFactory());
+
+        $haberdasherClient = new HaberdasherClient('www.example.com', $httpClient, null, null, '/not-twirp');
+
+        $this->expectException(Error::class);
+        $this->expectException(TwirpError::class);
+        $this->expectExceptionMessage('invalid path prefix "/not-twirp", expected "/twirp", on path "/not-twirp/twitch.twirp.example.Haberdasher/MakeHat"');
+
+        $haberdasherClient->MakeHat([], (new Size())->setInches(123));
+    }
 }

--- a/protoc-gen-twirp_php/templates/service/Server.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/Server.php.tmpl
@@ -117,9 +117,21 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
             return $this->writeError($ctx, $this->badRouteError($msg, $req->getMethod(), $req->getUri()->getPath()));
         }
 
-        switch ($req->getUri()->getPath()) {
+        list($prefix, $service, $method) = $this->parsePath($req->getUri()->getPath());
+
+        if ($service != '{{ .Service.Desc.FullName }}') {
+            return $this->writeError($ctx, $this->noRouteError($req));
+        }
+
+        if ($prefix != $this->prefix) {
+            $msg = sprintf('invalid path prefix "%s", expected "%s", on path "%s"', $prefix, $this->prefix, $req->getUri()->getPath());
+
+            return $this->writeError($ctx, $this->badRouteError($msg, $req->getMethod(), $req->getUri()->getPath()));
+        }
+
+        switch ($method) {
             {{- range $method := .Service.Methods }}
-            case $this->prefix.'/{{ $method | protoMethodFullName }}':
+            case '{{ $method.Desc.Name }}':
                 return $this->handle{{ $method.Desc.Name }}($ctx, $req);
             {{- end }}
 
@@ -237,6 +249,26 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
         return $resp;
     }
 {{- end }}
+
+    /**
+     * Extracts components from a path.
+     *
+     * Expected format: "[<prefix>]/<package>.<Service>/<Method>"
+     */
+    private function parsePath(string $path): array
+    {
+        $parts = explode('/', $path);
+
+        if (count($parts) < 2) {
+            return ["", "", ""];
+        }
+
+        $method = $parts[count($parts) - 1];
+        $service = $parts[count($parts) - 2];
+        $prefix = implode('/', array_slice($parts, 0, count($parts) - 2));
+
+        return [$prefix, $service, $method];
+    }
 
     /**
      * Used when there is no route for a request.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**

Return error if the service name matches, but the prefix doesn't.

**What this PR does / why we need it**

v7 spec made it possible to replace the /twirp prefix with custom prefixes.
I guess this extra check is in there to help clients address prefix issues instead of getting weird not found errors.

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Non-matching prefix is now returned as a separate error.
```
