### PR TITLE
Send TwirPHP-Version header from clients

### DIFF
--- a/protoc-gen-twirp_php/internal/gen/generator.go
+++ b/protoc-gen-twirp_php/internal/gen/generator.go
@@ -18,10 +18,11 @@ var globalTemplates = template.Must(template.New("").Funcs(TxtFuncMap()).ParseFS
 var serviceTemplates = template.Must(template.New("").Funcs(TxtFuncMap()).ParseFS(service.FS(), "*.php.tmpl"))
 
 type serviceFileData struct {
-	File         *protogen.File
-	Service      *protogen.Service
-	TwirpVersion string
-	Version      string
+	File           *protogen.File
+	Service        *protogen.Service
+	TwirpVersion   string
+	TwirphpVersion string
+	Version        string
 }
 
 type globalFileData struct {
@@ -51,10 +52,11 @@ func Generate(plugin *protogen.Plugin, version string) error {
 				generatedFile := plugin.NewGeneratedFile(fileName, "")
 
 				data := &serviceFileData{
-					File:         file,
-					Service:      svc,
-					TwirpVersion: twirpVersion,
-					Version:      version,
+					File:           file,
+					Service:        svc,
+					TwirpVersion:   twirpVersion,
+					TwirphpVersion: version,
+					Version:        version,
 				}
 
 				err := tpl.Execute(generatedFile, data)

--- a/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
@@ -125,7 +125,9 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
             ->withBody($body)
             ->withHeader('Accept', $contentType)
             ->withHeader('Content-Type', $contentType)
-            ->withHeader('Twirp-Version', '{{ .TwirpVersion }}');
+            ->withHeader('Twirp-Version', '{{ .TwirpVersion }}')
+            ->withHeader('TwirPHP-Version', '{{ .TwirphpVersion }}')
+        ;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**

Send TwirPHP-Version header from clients

**What this PR does / why we need it**

Currently clients send a Twirp-Version header that contains the supported Go library version.
This PR adds a new header containing the TwirPHP version.

In a future version, we should probably drop Twirp-Version completely.

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
