### PR TITLE
fix: fixed installation command with curl in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Download prebuilt binaries for the protoc plugin from the [releases](https://git
 Alternatively, you can use the following oneliner to install the plugin:
 
 ```bash
-curl -Ls https://git.io/twirphp | bash -b path/to/bin
+curl -Ls https://git.io/twirphp | bash -s -- -b path/to/bin
 ```
 
 See the [documentation](https://twirphp.github.io/docs/installation) for details.


### PR DESCRIPTION
**Overview**

Fixed installation instruction in readme. Its need to pass `-b` flag after `-s --` construction