### PR TITLE
Only generate global templates when there are services in a namespace

### DIFF
--- a/protoc-gen-twirp_php/internal/gen/generator.go
+++ b/protoc-gen-twirp_php/internal/gen/generator.go
@@ -37,9 +37,10 @@ func Generate(plugin *protogen.Plugin, version string) error {
 	namespaces := map[string]bool{}
 
 	for _, file := range plugin.Files {
-		namespaces[php.Namespace(file)] = true
-
 		for _, svc := range file.Services {
+			// Namespaces are only relevant when there are services defined in them
+			namespaces[php.Namespace(file)] = true
+
 			for _, tpl := range serviceTemplates.Templates() {
 				fileName := fmt.Sprintf(
 					"%s/%s%s",


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**

Only generate global templates when there are services in a namespace

**What this PR does / why we need it**

Fixes #100

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
TwirpError won't be generated when no services are present in a namespace
```
