### PR TITLE
Allow using the install script on arm64

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,8 +65,11 @@ is_supported_platform() {
   found=1
   case "$platform" in
     linux/amd64) found=0 ;;
+    linux/arm64) found=0 ;;
     darwin/amd64) found=0 ;;
+    darwin/arm64) found=0 ;;
     windows/amd64) found=0 ;;
+    windows/arm64) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
The generated install.sh was missing the entries for arm64, even though goreleaser already builds the respective packages.