### PR TITLE
Fix implicitly null parameter types in templates

### DIFF
--- a/protoc-gen-twirp_php/templates/global/TwirpError.php.tmpl
+++ b/protoc-gen-twirp_php/templates/global/TwirpError.php.tmpl
@@ -23,7 +23,7 @@ final class TwirpError extends \Exception implements Error
      */
     private $meta = [];
 
-    public function __construct(string $code, string $message, int $exCode = 0, \Throwable $previous = null)
+    public function __construct(string $code, string $message, int $exCode = 0, ?\Throwable $previous = null)
     {
         $this->errorCode = $code;
 
@@ -72,7 +72,7 @@ final class TwirpError extends \Exception implements Error
      * error {type: Internal, msg: "invalid error type {code}"}. If you need to
      * add metadata, use setMeta(key, value) method after building the error.
      */
-    public static function newError(string $code, string $msg, \Throwable $previous = null): self
+    public static function newError(string $code, string $msg, ?\Throwable $previous = null): self
     {
         if (ErrorCode::isValid($code)) {
             return new self($code, $msg, 0, $previous);

--- a/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
@@ -53,9 +53,9 @@ abstract class {{ .Service | phpServiceName .File }}AbstractClient
 
     public function __construct(
         $addr,
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {

--- a/protoc-gen-twirp_php/templates/service/Server.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/Server.php.tmpl
@@ -62,9 +62,9 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
 
     public function __construct(
         {{ .Service | phpServiceName .File }} $svc,
-        ServerHooks $hook = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ServerHooks $hook = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($hook === null) {


### PR DESCRIPTION
**Overview**

Fix implicitly null parameter types in templates.

**What this PR does / why we need it**

In PHP 8.4, implicitly nullable parameter types will be deprecated. Read [the RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) for more details. This change will prevent a deprecation warning once PHP 8.4 is released. It has no effect on earlier PHP versions.

Instances of this were already fixed via php-cs-fixer in non-templated code, so this is also more consistent within the code base.

**Does this PR introduce a user-facing change?**

```release-note
Prevent deprecation warnings on PHP 8.4.
```
