### PR TITLE
Fix nested Request & Response messages

### DIFF
--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -143,18 +143,17 @@ func MessageName(file *protogen.File, message *protogen.Message) string {
 }
 
 func findParentMessage(message *protogen.Message) *protoreflect.MessageDescriptor {
-    parentFile := message.Desc.ParentFile()
+  parentFile := message.Desc.ParentFile()
 
-    for i := 0; i < parentFile.Messages().Len(); i++ {
-        parentMessage := parentFile.Messages().Get(i)
-
-        for j := 0; j < parentMessage.Messages().Len(); j++ {
-            nestedMessage := parentMessage.Messages().Get(j)
-            if nestedMessage == message.Desc {
-                return &parentMessage
-            }
-        }
+  for i := 0; i < parentFile.Messages().Len(); i++ {
+    parentMessage := parentFile.Messages().Get(i)
+    for j := 0; j < parentMessage.Messages().Len(); j++ {
+      nestedMessage := parentMessage.Messages().Get(j)
+      if nestedMessage == message.Desc {
+          return &parentMessage
+      }
     }
+  }
 
-    return nil
+  return nil
 }

--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -130,8 +130,24 @@ func ServiceName(file *protogen.File, svc *protogen.Service) string {
 
 // MessageName transforms a message name into a PHP compatible one.
 func MessageName(file *protogen.File, message *protogen.Message) string {
-	className := string(message.Desc.Name())
-	parentFile := message.Desc.ParentFile()
+  var classNameParts []string
 
-	return "\\" + namespacedName(classNamePrefix(className, parentFile)+className, parentFile)
+  parentFile := message.Desc.ParentFile()
+
+  for i := 0; i < parentFile.Messages().Len(); i++ {
+    parentMessage := parentFile.Messages().Get(i)
+
+    for j := 0; j < parentMessage.Messages().Len(); j++ {
+      nestedMessage := parentMessage.Messages().Get(j)
+      if nestedMessage == message.Desc {
+        classNameParts = append(classNameParts, string(parentMessage.Name()))
+        break
+      }
+    }
+  }
+
+  classNameParts = append(classNameParts, string(message.Desc.Name()))
+  className := strings.Join(classNameParts, "\\")
+
+  return "\\" + namespacedName(classNamePrefix(className, parentFile)+className, parentFile)
 }

--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -143,13 +143,14 @@ func MessageName(file *protogen.File, message *protogen.Message) string {
 }
 
 func findParentMessage(message *protogen.Message) *protoreflect.MessageDescriptor {
-  parentFile := message.Desc.ParentFile()
+  parentFileMessages := message.Desc.ParentFile().Messages()
 
-  for i := 0; i < parentFile.Messages().Len(); i++ {
-    parentMessage := parentFile.Messages().Get(i)
-    for j := 0; j < parentMessage.Messages().Len(); j++ {
-      nestedMessage := parentMessage.Messages().Get(j)
-      if nestedMessage == message.Desc {
+  for i := 0; i < parentFileMessages.Len(); i++ {
+    parentMessage := parentFileMessages.Get(i)
+    nestedMessages := parentMessage.Messages()
+
+    for j := 0; j < nestedMessages.Len(); j++ {
+      if nestedMessages.Get(j) == message.Desc {
           return &parentMessage
       }
     }

--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -131,13 +131,12 @@ func ServiceName(file *protogen.File, svc *protogen.Service) string {
 // MessageName transforms a message name into a PHP compatible one.
 func MessageName(file *protogen.File, message *protogen.Message) string {
   var classNameParts []string
-
   if parentMessage := findParentMessage(message); parentMessage != nil {
     classNameParts = append(classNameParts, string((*parentMessage).Name()))
   }
-
   classNameParts = append(classNameParts, string(message.Desc.Name()))
   className := strings.Join(classNameParts, "\\")
+
   parentFile := message.Desc.ParentFile()
 
   return "\\" + namespacedName(classNamePrefix(className, parentFile)+className, parentFile)


### PR DESCRIPTION
**Overview**

This PR allows to use nested Request messages in service classes (fixes a bug linked below).

**What this PR does / why we need it**

- Closes #201

```proto
syntax = "proto3";

package org.example;

service EmployeeService {
  rpc ListEmployee(ListEmployee.Request) returns (ListEmployee.Response);
}

message ListEmployee {
  message Request {
    string organization_id = 1;
  }

  message Response {
    oneof response {
      Result result = 1;
      string access_denied = 2;
    }

    message Result {
      repeated Employee employees = 1;
    }

    message Employee {
      string id = 1;
      string name = 2;
    }
  }
}
```

Will generate:
```php
interface EmployeeService
{
    public function ListEmployee(
        array $ctx,
        \Org\Example\ListEmployee\Request $req
    ): \Org\Example\ListEmployee\Response;
}
```

Instead of:
```php
interface EmployeeService
{
    public function ListEmployee(
        array $ctx,
        \Org\Example\Request $req
    ): \Org\Example\Response;
}
```

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

```release-note
Added support of nested Request & Response messages: https://github.com/twirphp/twirp/issues/201
```
