### PR TITLE
Simplify Server registration

### DIFF
--- a/lib/src/Router.php
+++ b/lib/src/Router.php
@@ -52,6 +52,11 @@ final class Router implements RequestHandlerInterface
         $this->handlers[$path] = $handler;
     }
 
+    public function registerServer(ServerInterface $server): void
+    {
+        $this->handlers[$server->getPathPrefix()] = $server;
+    }
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         foreach ($this->handlers as $path => $handler) {

--- a/lib/src/ServerInterface.php
+++ b/lib/src/ServerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Twirp;
+
+use Psr\Http\Server\RequestHandlerInterface;
+
+interface ServerInterface extends RequestHandlerInterface
+{
+    /**
+     * Returns the base service path, in the form: "/<prefix>/<package>.<Service>/"
+     * that is everything in a Twirp route except for the <Method>. This can be used for routing,
+     * for example to identify the requests that are targeted to this service in a mux.
+     */
+    public function getPathPrefix(): string;
+}

--- a/protoc-gen-twirp_php/templates/service/Server.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/Server.php.tmpl
@@ -12,18 +12,18 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 use Twirp\BaseServerHooks;
 use Twirp\Context;
 use Twirp\ErrorCode;
 use Twirp\ServerHooks;
+use Twirp\ServerInterface;
 
 /**
  * @see {{ .Service | phpServiceName .File }}
  *
  * Generated from protobuf service <code>{{ .Service.Desc.FullName }}</code>
  */
-final class {{ .Service | phpServiceName .File }}Server implements RequestHandlerInterface
+final class {{ .Service | phpServiceName .File }}Server implements ServerInterface
 {
     /**
      * A convenience constant that may identify URL paths.


### PR DESCRIPTION
**Overview**

Simplify registration of server, because PATH_PREFIX constant declares:

> Should be used with caution, it only matches routes with the default "/twirp" prefix and default CamelCase service and method names. Use EmployeeServiceServer::getPathPrefix instead.

**What this PR does / why we need it**

Instead of this:
```php
$this->router->registerHandler(
    EmployeeServiceServer::PATH_PREFIX,
    new EmployeeServiceServer(svc: $this->employeeService),
);
```

Or this:
```php
$employeeServiceServer = new EmployeeServiceServer(
    svc: $this->employeeService,
);

$this->router->registerHandler(
    $employeeServiceServer->getPathPrefix(),
    $employeeServiceServer,
);
```

We can do:
```php
$this->router->registerServer(
    new EmployeeServiceServer(
        svc: $this->employeeService,
    )
);
```

**Special notes for your reviewer**

**Does this PR introduce a user-facing change?**

```release-note
New ability to register server without manually define server path.
```
