### PR TITLE
Fix nested message name generation

### DIFF
--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -127,11 +127,12 @@ func ServiceName(file *protogen.File, svc *protogen.Service) string {
 }
 
 // MessageName transforms a message name into a PHP compatible one.
-func MessageName(file *protogen.File, message *protogen.Message) string {
-	parentFile := message.Desc.ParentFile()
-	className := classNamePrefix(string(message.Desc.Name()), parentFile) + string(message.Desc.Name())
+func MessageName(_ *protogen.File, message *protogen.Message) string {
+	desc := message.Desc
+	parentFile := desc.ParentFile()
+	className := classNamePrefix(string(desc.Name()), parentFile) + string(desc.Name())
 
-	for parent, ok := message.Desc.Parent().(protoreflect.MessageDescriptor); ok && parent != nil; parent, ok = parent.Parent().(protoreflect.MessageDescriptor) {
+	for parent, ok := desc.Parent().(protoreflect.MessageDescriptor); ok && parent != nil; parent, ok = parent.Parent().(protoreflect.MessageDescriptor) {
 		className = classNamePrefix(string(parent.Name()), parentFile) + string(parent.Name()) + "\\" + className
 	}
 

--- a/protoc-gen-twirp_php/internal/php/func.go
+++ b/protoc-gen-twirp_php/internal/php/func.go
@@ -13,6 +13,8 @@ import (
 // https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/compiler/php/names.cc
 
 // Reserved PHP keywords that must be prefixed with something.
+//
+// Source: https://github.com/protocolbuffers/protobuf/blob/6e393fd79667597aac2bb42511fb30c31ff1611d/src/google/protobuf/compiler/php/names.cc
 var reservedNames = []string{
 	"abstract", "and", "array", "as", "break",
 	"callable", "case", "catch", "class", "clone",
@@ -20,15 +22,16 @@ var reservedNames = []string{
 	"do", "echo", "else", "elseif", "empty",
 	"enddeclare", "endfor", "endforeach", "endif", "endswitch",
 	"endwhile", "eval", "exit", "extends", "final",
-	"for", "foreach", "function", "global", "goto",
-	"if", "implements", "include", "include_once", "instanceof",
-	"insteadof", "interface", "isset", "list", "namespace",
-	"new", "or", "print", "private", "protected",
-	"public", "require", "require_once", "return", "static",
-	"switch", "throw", "trait", "try", "unset",
-	"use", "var", "while", "xor", "int",
-	"float", "bool", "string", "true", "false",
-	"null", "void", "iterable",
+	"finally", "fn", "for", "foreach", "function",
+	"global", "goto", "if", "implements", "include",
+	"include_once", "instanceof", "insteadof", "interface", "isset",
+	"list", "match", "namespace", "new", "or",
+	"parent", "print", "private", "protected", "public",
+	"readonly", "require", "require_once", "return", "self",
+	"static", "switch", "throw", "trait", "try",
+	"unset", "use", "var", "while", "xor",
+	"yield", "int", "float", "bool", "string",
+	"true", "false", "null", "void", "iterable",
 }
 
 // ClassNamePrefix calculates class name prefix.

--- a/tests/namespace/test.php
+++ b/tests/namespace/test.php
@@ -42,3 +42,4 @@ Assert::classExists(\Twirp\Tests\Namespace\Proto\HaberdasherServer::class);
 Assert::classExists(\Twirp\Tests\Namespace\Proto\HaberdasherAbstractClient::class);
 Assert::classExists(\Twirp\Tests\Namespace\Proto\HaberdasherJsonClient::class);
 Assert::interfaceExists(\Twirp\Tests\Namespace\Proto\Haberdasher::class);
+Assert::exit();


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

**Overview**

Fix nested message name generation

Updated PHP name generation based on the original compiler code: https://github.com/protocolbuffers/protobuf/blob/6e393fd79667597aac2bb42511fb30c31ff1611d/src/google/protobuf/compiler/php/names.cc

**What this PR does / why we need it**

Fixes #201
Fixes #203
