### PR TITLE
Add psr/http-message v2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php-http/discovery": "^1.19",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-server-handler": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
**Overview**

Replacement for:
- #124

**What this PR does / why we need it**

Allows to use this package with modern software.

**Special notes for your reviewer**

I checked which versions are supported commonly:
```
guzzlehttp/psr7                 2.7.1                                           requires psr/http-message (^1.1 || ^2.0) 
php-http/client-common          2.7.2                                           requires psr/http-message (^1.0 || ^2.0) 
php-http/httplug                2.4.1                                           requires psr/http-message (^1.0 || ^2.0) 
php-http/httplug-bundle         2.1.0                                           requires psr/http-message (^1.0 || ^2.0) 
php-http/message                1.16.2                                          requires psr/http-message (^1.1 || ^2.0) 
psr/http-client                 1.0.3                                           requires psr/http-message (^1.0 || ^2.0) 
psr/http-factory                1.1.0                                           requires psr/http-message (^1.0 || ^2.0) 
psr/http-server-handler         1.0.2                                           requires psr/http-message (^1.0 || ^2.0) 
symfony/psr-http-message-bridge v7.2.0                                          requires psr/http-message (^1.0|^2.0)
```

**Does this PR introduce a user-facing change?**

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```
