### PR TITLE
Fix AbstractClient.php.tmpl property type

### DIFF
--- a/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/AbstractClient.php.tmpl
@@ -27,7 +27,7 @@ use Twirp\ErrorCode;
 abstract class {{ .Service | phpServiceName .File }}AbstractClient
 {
     /**
-     * @var server
+     * @var string
      */
     protected $addr;
 


### PR DESCRIPTION
**Overview**

Looks like a typo in DocBlock.
