### PR TITLE
Introduce support for emitting defaults for json responses

### DIFF
--- a/lib/src/CanEmitJsonDefaults.php
+++ b/lib/src/CanEmitJsonDefaults.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Twirp;
+
+interface CanEmitJsonDefaults
+{
+    public function setEmitJsonDefaults(bool $emitDefaults): void;
+
+    public function shouldEmitJsonDefaults(): bool;
+}

--- a/protoc-gen-twirp_php/templates/service/Server.php.tmpl
+++ b/protoc-gen-twirp_php/templates/service/Server.php.tmpl
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Twirp\BaseServerHooks;
+use Twirp\CanEmitJsonDefaults;
 use Twirp\Context;
 use Twirp\ErrorCode;
 use Twirp\ServerHooks;
@@ -25,7 +26,7 @@ use Twirp\ServerWithPathPrefix;
  *
  * Generated from protobuf service <code>{{ .Service.Desc.FullName }}</code>
  */
-final class {{ .Service | phpServiceName .File }}Server implements RequestHandlerInterface, ServerWithPathPrefix
+final class {{ .Service | phpServiceName .File }}Server implements RequestHandlerInterface, ServerWithPathPrefix, CanEmitJsonDefaults
 {
     /**
      * A convenience constant that may identify URL paths.
@@ -53,12 +54,18 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
      */
     private $prefix;
 
+    /**
+     * @var bool
+     */
+    private $emitDefaults = false;
+
     public function __construct(
         {{ .Service | phpServiceName .File }} $svc,
         ?ServerHooks $hook = null,
         ?ResponseFactoryInterface $responseFactory = null,
         ?StreamFactoryInterface $streamFactory = null,
-        string $prefix = '/twirp'
+        string $prefix = '/twirp',
+        bool $emitDefaults = false
     ) {
         if ($hook === null) {
             $hook = new BaseServerHooks();
@@ -77,6 +84,7 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
         $this->responseFactory = $responseFactory;
         $this->streamFactory = $streamFactory;
         $this->prefix = rtrim($prefix, '/');
+        $this->setEmitJsonDefaults($emitDefaults);
     }
 
     /**
@@ -196,7 +204,13 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
             return $this->writeError($ctx, $e);
         }
 
-        $data = $out->serializeToJsonString();
+        if ($this->shouldEmitJsonDefaults()) {
+            // Only supported in protobuf v5.34.0 or greater.
+            // @phpstan-ignore class.notFound, arguments.count
+            $data = $out->serializeToJsonString(\Google\Protobuf\PrintOptions::EMIT_DEFAULTS);
+        } else {
+            $data = $out->serializeToJsonString();
+        }
 
         $body = $this->streamFactory->createStream($data);
 
@@ -374,5 +388,29 @@ final class {{ .Service | phpServiceName .File }}Server implements RequestHandle
             // likely that the connection is broken and the original 'err' says
             // so anyway.
         }
+    }
+
+    /**
+     * By default, protobuf will filter out default values from your return value.
+     * This changes that behavior to always emit default values, allowing for clearer
+     * responses for non-generated or customized clients.
+     * Only supported on versions greater than or equal v5.34.0 of the protobuf package or extension.
+     * Will be a noop if on older versions.
+     *
+     * When false (default): `{myVal: 0, myStr: "hi"}` -> `{myStr: "hi"}`
+     * When true: `{myVal: 0, myStr: "hi"}` -> `{myVal: 0, myStr: "hi"}`
+     */
+    public function setEmitJsonDefaults(bool $emitDefaults): void
+    {
+        $this->emitDefaults = $emitDefaults;
+    }
+
+    public function shouldEmitJsonDefaults(): bool
+    {
+        if (!defined('Google\\Protobuf\\PrintOptions::EMIT_DEFAULTS')) {
+            return false;
+        }
+
+        return $this->emitDefaults;
     }
 }


### PR DESCRIPTION

**Overview**

By default, protobuf responses do not include default values, even for json. This can make inspecting json responses through curl or custom clients rather confusing, as entire fields may be absent. Guidance from protobuf (https://protobuf.dev/programming-guides/json/#json-options) is that languages may (or may not) provide options to override this behavior and emit all default values. In https://github.com/protocolbuffers/protobuf/pull/23985 I added this option to PHP's protobuf generation tooling, and would love to use it in twirphp (please note a release version of protobuf with this option is not yet cut). I also felt like with this (and the existing `getPathPrefix`), it would be nice to have an interface that describes the "global" (as in present on all twirp generated servers) funcs available, so I added `Twirp\ServerInterface`.

**What this PR does / why we need it**

- Allows an opt-in setting for emitting default values when returning JSON
- Dances around requiring newer protobuf versions by checking if the new protobuf option is declared or not
- Adds an interface with the new functions + `getPathPrefix`

**Special notes for your reviewer**

Before I work on adding tests and promoting this out of a draft state, I wanted some clarity from the maintainers:

- [x]  Are y'all OK with the interface, or do you prefer I not add that?
- [x]  Do you care if I maintain backwards compatibility with older protobuf package+extension versions, or should we just upgrade the minimum required version?
- [x]  Do you want me to log a warning or anything if someone calls `setEmitJsonDefaults(true)` and does not have the required protobuf package option available? Currently I do a silent noop as we don't have a user provided logger.

**Does this PR introduce a user-facing change?**

Yes.

```release-note
- Added new `Twirp\ServerInterface` for those who need an interface for a generated server's functions available beyond `Psr\Http\Server\RequestHandlerInterface`
- Added  support for `setEmitJsonDefaults`, allowing you to always emit default values for json responses when using protobuf package and extension versions greater than v4.33.0.
```
